### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v1.4.3
+        with:
+          node-version: 12.x 
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check types
+        run: npx tsc -p .
+
+      - name: Test example app
+        run: |
+          npm ci
+          npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -856,6 +856,12 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typescript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,31 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.49",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+      "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.63.18",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.18.tgz",
+      "integrity": "sha512-WwEWqmHiqFn61M1FZR/+frj+E8e2o8i5cPqu9mjbjtZS/gBfCKVESF2ai/KAlaQECkkWkx/nMJeCc5eHMmLQgw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "acorn": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
@@ -232,6 +257,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "csstype": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+      "dev": true
     },
     "debug": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "react-native-vector-icons": ">= 6.x.x"
   },
   "devDependencies": {
+    "@types/react": "^16.9.49",
+    "@types/react-native": "^0.63.18",
     "eslint": "^7.0.0",
     "typescript": "^4.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-native-vector-icons": ">= 6.x.x"
   },
   "devDependencies": {
-    "eslint": "^7.0.0"
+    "eslint": "^7.0.0",
+    "typescript": "^4.0.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "jsx": "react",
+    "noEmit": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": false,
+    "lib": ["esnext"]
+  }
+}


### PR DESCRIPTION
Hi @WrathChaos -- thanks for this library!

I wanted to chip in on FontAwesome5 (#30), but I like to make sure there are CI actions / tests to verify my changes before messing with anything. Makes it easier to review & justify changes IMO.

So, here is a basic GitHub action that

- checks types
- runs tests in `example` (currently just a basic App render test, but still something)

---

In order to make this change, I needed to add `typescript` as a devDependency and add a basic `tsconfig.json`, as well as add `@types` for react-native and react.

An example run of the action can be observed here: https://github.com/davidgovea/react-native-dynamic-vector-icons/actions/runs/249155545

Thanks for reading! Let me know if you'd like any changes/renames or rebase/squashing